### PR TITLE
fix: do not check config too early

### DIFF
--- a/source/php/Asset/AssetInterface.php
+++ b/source/php/Asset/AssetInterface.php
@@ -10,6 +10,7 @@ use WpService\Contracts\WpRegisterStyle;
 
 interface AssetInterface
 {
+  public function shouldEnqueue(): bool;
   public function getHook(): string;
   public function getHandle(): string;
   public function getFilename(): string;

--- a/source/php/Asset/AssetRegistry.php
+++ b/source/php/Asset/AssetRegistry.php
@@ -104,6 +104,10 @@ abstract class AssetRegistry implements Hookable, AssetInterface
 
     public function enqueue(): void
     {
+        if($this->isEnabled() === false) {
+            return;
+        }
+
         $filename = $this->getFilename();
 
         if ($this->getType($filename) === 'css') {

--- a/source/php/Asset/ContextDetection.php
+++ b/source/php/Asset/ContextDetection.php
@@ -6,6 +6,11 @@ use BrokenLinkDetector\Asset\AssetRegistry;
 
 class ContextDetection extends AssetRegistry implements AssetInterface
 {
+  public function shouldEnqueue(): bool
+  {
+    return $this->config->isContextCheckEnabled();
+  }
+
   public function getHook(): string
   {
     return 'wp_enqueue_scripts';

--- a/source/php/Asset/EditorHighlight.php
+++ b/source/php/Asset/EditorHighlight.php
@@ -6,6 +6,11 @@ use BrokenLinkDetector\Asset\AssetRegistry;
 
 class EditorHighlight extends AssetRegistry implements AssetInterface
 {
+  public function shouldEnqueue(): bool
+  {
+    return true;
+  }
+
   public function getHook(): string
   {
     return 'mce_external_plugins';

--- a/source/php/Asset/FrontendStyles.php
+++ b/source/php/Asset/FrontendStyles.php
@@ -6,6 +6,11 @@ use BrokenLinkDetector\Asset\AssetRegistry;
 
 class FrontendStyles extends AssetRegistry implements AssetInterface
 {
+  public function shouldEnqueue(): bool
+  {
+    return true;
+  }
+
   public function getHook(): string
   {
     return 'wp_enqueue_scripts';


### PR DESCRIPTION
This pull request introduces a new method `shouldEnqueue` to the `AssetInterface` and implements it across various classes. This change aims to provide a consistent way to determine if an asset should be enqueued based on certain conditions.

### Interface Update:
* Added `shouldEnqueue` method to the `AssetInterface` to standardize the enqueue check across different asset types.

### Method Implementations:
* Implemented `shouldEnqueue` method in `ContextDetection` to return the result of `isContextCheckEnabled` configuration.
* Implemented `shouldEnqueue` method in `EditorHighlight` to always return `true`.
* Implemented `shouldEnqueue` method in `FrontendStyles` to always return `true`.

### Enqueue Logic Enhancement:
* Updated the `enqueue` method in `AssetRegistry` to check `isEnabled` before proceeding with the enqueue process.